### PR TITLE
remove equal signs from exports

### DIFF
--- a/lib/generators/templates/array_controller.js.es6
+++ b/lib/generators/templates/array_controller.js.es6
@@ -1,4 +1,4 @@
-export default = Ember.ArrayController.extend({
+export default Ember.ArrayController.extend({
 
 });
 

--- a/lib/generators/templates/component.js.es6
+++ b/lib/generators/templates/component.js.es6
@@ -1,2 +1,2 @@
-export default = Ember.Component.extend({
+export default Ember.Component.extend({
 });

--- a/lib/generators/templates/controller.js.es6
+++ b/lib/generators/templates/controller.js.es6
@@ -1,3 +1,3 @@
-export default = Ember.Controller.extend({
+export default Ember.Controller.extend({
 
 });

--- a/lib/generators/templates/model.js.es6
+++ b/lib/generators/templates/model.js.es6
@@ -1,4 +1,4 @@
-export default = DS.Model.extend({
+export default DS.Model.extend({
 <% attributes.each_with_index do |attribute, idx| -%>
   <%= attribute[:name].camelize(:lower) %>: <%=
   if %w(references belongs_to).member?(attribute[:type])

--- a/lib/generators/templates/object_controller.js.es6
+++ b/lib/generators/templates/object_controller.js.es6
@@ -1,4 +1,4 @@
-export default = Ember.ObjectController.extend({
+export default Ember.ObjectController.extend({
 
 });
 

--- a/lib/generators/templates/route.js.es6
+++ b/lib/generators/templates/route.js.es6
@@ -1,3 +1,3 @@
-export default = Ember.Route.extend({
+export default Ember.Route.extend({
 
 });

--- a/lib/generators/templates/router.js.es6
+++ b/lib/generators/templates/router.js.es6
@@ -4,4 +4,4 @@ Router.map(function() {
 
 });
 
-export default = Router;
+export default Router;

--- a/lib/generators/templates/view.js.es6
+++ b/lib/generators/templates/view.js.es6
@@ -1,3 +1,3 @@
-export default = Ember.View.extend({
+export default Ember.View.extend({
 
 });

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -21,7 +21,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   test "leave parentheses when create model w/o attributes" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/models/post.js.es6", /export default = DS.Model.extend/
+    assert_file "app/assets/javascripts/models/post.js.es6", /export default DS.Model.extend/
   end
 
   test "Assert files are properly created" do


### PR DESCRIPTION
this makes the generated files pass jshint.

This is a follow up to #47.

I'm not sure if it makes sense to merge this now or wait for the spec to settle. I leave this here for reference.
