### PR TITLE
Bump es6_module_transpiler-rails

### DIFF
--- a/ember-appkit-rails.gemspec
+++ b/ember-appkit-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'rails', '~> 4.0.0'
-  s.add_dependency 'es6_module_transpiler-rails', '~> 0.0.3'
+  s.add_dependency 'es6_module_transpiler-rails', '~> 0.1.0'
   s.add_dependency 'ember-rails', '>= 0.14.0'
   s.add_dependency 'ember-source', '~> 1.2.0'
   s.add_dependency 'ember-data-source', '~> 1.0.0.beta.3'


### PR DESCRIPTION
Fixes "SyntaxError: Unexpected strict mode reserved word" during assets precompilation.
