### PR TITLE
Bootstrap into top-level directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Updated es6\_module\_transpiler-rails gem - Wouter Willaert
 * Corrected Title in in Welcome Page - Lin Reid
 * Remove jquery\_ujs from application.js on bootstrap - Brian Cardarella
+* Bootstrap into top-level `appkit/` directory - Brian Cardarella

--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ only).
 
 ## Usage ##
 
+### Configuration ###
+
+#### Asset Path ####
+
+The default file asset path for `eak-rails` files is `appkit/`. The
+generators will write files to that directory by default instead of
+`app/assets/javascripts`. To change this you'll have to modify the
+configuration:
+
+```ruby
+config.ember_appkit.asset_path = 'app/assets/javascripts'
+``` 
+
+Adding this to your `config/application.rb` file will generate your
+assets into `app/assets/javascripts` instead of `appkit/`
+
+#### AMD Module Namespacing ####
+
+The default AMD namespace is `appkit`. Modify this in your
+`config/application.rb`
+
+```ruby
+config.ember_appkit.namespace = 'ember'
+``` 
+
 ### Generators ###
 
 Ember Appkit Rails provides the following generators:
@@ -33,68 +58,68 @@ Ember Appkit Rails provides the following generators:
 
   Initializes Ember Appkit Rails into your project by creating the required files
   (`router.js.es6`, `ember-app.js.es6`, and the directory structure). Also, removes
-  `turbolinks` from `Gemfile`, `app/assets/javascripts/application.js`, and `app/views/layouts/application.html.erb`
-  and `jquery_js` from `app/assets/javascripts/application.js`.
+  `turbolinks` from `Gemfile`, `appkit/application.js`, and `app/views/layouts/application.html.erb`
+  and `jquery_js` from `appkit/application.js`.
 
   The following options are supported:
 
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
   * `--app-name` - This will be used to name the global variable referencing your application. Default value: `App`.
   * `--leave-turbolinks` - This will prevent the removal of `turbolinks`.
   * `--leave-jqueryujs` - This will prevent the removal of `jquery_ujs`.
 
 * `ember:route NAME`
 
-  Creates a route using the provided name in `app/assets/javascripts/routes/`.
+  Creates a route using the provided name in `appkit/routes/`.
 
   The following options are supported:
 
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:controller NAME`
 
-  Creates a controller using the provided name in `app/assets/javascripts/controllers/`.
+  Creates a controller using the provided name in `appkit/controllers/`.
 
   The following options are supported:
 
   * `--array` - Used to generate an `Ember.ArrayController`.
   * `--object` - Used to generate an `Ember.ObjectController`.
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:view NAME`
 
-  Creates a view using the provided name in `app/assets/javascripts/views/`.
+  Creates a view using the provided name in `appkit/views/`.
 
   The following options are supported:
 
   * `--without-template` - Used to prevent creating a template for the generated view.
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:component NAME`
 
-  Creates a component in `app/assets/javascripts/components/` and a template in `app/assets/javascripts/templates/components/`.
+  Creates a component in `appkit/components/` and a template in `appkit/templates/components/`.
 
   The following options are supported:
 
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:template NAME`
 
-  Creates a template using the provided name in `app/assets/javascripts/templates/`.
+  Creates a template using the provided name in `appkit/templates/`.
 
   The following options are supported:
 
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `/app/assets/javascripts`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `/appkit`.
 
 * `ember:model NAME [ATTRIBUTES]`
 
-  Creates a model using the provided name in `app/assets/javascripts/models/`.
+  Creates a model using the provided name in `appkit/models/`.
 
   Accepts a list of a attributes to setup on the generated model.
 
   The following options are supported:
 
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:resource NAME`
 
@@ -105,11 +130,11 @@ Ember Appkit Rails provides the following generators:
   * `--array` - Used to generate an `Ember.ArrayController`.
   * `--object` - Used to generate an `Ember.ObjectController`.
   * `--skip-route` - When present a route will not be generated.
-  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `app/assets/javascripts/`.
+  * `--ember-path` - This is the root path to be used for your Ember application. Default value: `appkit/`.
 
 * `ember:helper NAME`
 
-  Creates a helper using the provided name in `app/assets/javascripts/helpers/`.
+  Creates a helper using the provided name in `appkit/helpers/`.
 
 #### Rails Generators ####
 

--- a/lib/ember/appkit/rails/engine.rb
+++ b/lib/ember/appkit/rails/engine.rb
@@ -2,6 +2,7 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
   config.ember_appkit = ActiveSupport::OrderedOptions.new
 
   config.ember_appkit.namespace = 'appkit'
+  config.ember_appkit.asset_path = config.ember_appkit.namespace
   config.ember_appkit.prefix_pattern = /^(controllers|models|views|helpers|routes|router|adapter)/
 
   config.ember_appkit.enable_logging = ::Rails.env.development?
@@ -18,5 +19,9 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
     app.routes.append do
       get '/' => "rails/welcome#index"
     end
+  end
+
+  initializer :add_appkit_asset_path do
+    Sprockets::Railtie.config.assets.paths.unshift(File.join(::Rails.root, config.ember_appkit.asset_path))
   end
 end

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -82,8 +82,8 @@ module Ember
       end
 
       def inject_into_application_file
-        application_file = "#{ember_path}/application.js"
-        inject_into_file( application_file, :before => /^.*require_tree.*$/) do
+        application_file = File.join(javascript_assets_path, 'application.js')
+        inject_into_file(application_file, :before => /^.*require_tree.*$/) do
           context = instance_eval('binding')
           source  = File.expand_path(find_in_source_paths("application.js.erb"))
           ERB.new(::File.binread(source), nil, '-', '@output_buffer').result(context)
@@ -91,7 +91,7 @@ module Ember
       end
 
       def jquery?
-        content  = File.read(File.expand_path("#{ember_path}/application.js", destination_root))
+        content = File.read(File.join(javascript_assets_path, 'application.js'))
         content.scan(/\/\/= require jquery\n/).size > 0
       end
     end

--- a/lib/generators/ember/generator_helpers.rb
+++ b/lib/generators/ember/generator_helpers.rb
@@ -12,7 +12,7 @@ module Ember
         elsif rails_engine?
           "app/assets/javascripts/#{engine_name}"
         else
-          "app/assets/javascripts"
+          'appkit'
         end
       end
 
@@ -32,7 +32,7 @@ module Ember
         elsif rails_engine?
           engine_name
         else
-          "App"
+          'App'
         end
       end
 
@@ -42,6 +42,10 @@ module Ember
 
       def handlebars_template_path
         File.join(class_path, file_name).gsub(/^\//, '')
+      end
+
+      def javascript_assets_path
+        File.join(::Rails.root, 'app/assets/javascripts')
       end
 
       def configuration

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -11,8 +11,8 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
   test "default_component" do
     run_generator ["PostChart"]
-    assert_file "app/assets/javascripts/components/post-chart_component.js.es6"
-    assert_file "app/assets/javascripts/templates/components/post-chart.hbs"
+    assert_file "appkit/components/post-chart_component.js.es6"
+    assert_file "appkit/templates/components/post-chart.hbs"
   end
 
   test "Assert files are properly created (CamelCase)" do

--- a/test/generators/controller_generator_test.rb
+++ b/test/generators/controller_generator_test.rb
@@ -11,17 +11,17 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   test "array_controller" do
     run_generator ["post", "--array"]
-    assert_file "app/assets/javascripts/controllers/post.js.es6"
+    assert_file "appkit/controllers/post.js.es6"
   end
 
   test "object_controller" do
     run_generator ["post", "--object"]
-    assert_file "app/assets/javascripts/controllers/post.js.es6"
+    assert_file "appkit/controllers/post.js.es6"
   end
 
   test "default_controller" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/controllers/post.js.es6"
+    assert_file "appkit/controllers/post.js.es6"
   end
 
   test "Assert files are properly created" do

--- a/test/generators/helper_generator_test.rb
+++ b/test/generators/helper_generator_test.rb
@@ -11,6 +11,6 @@ class HelperGeneratorTest < Rails::Generators::TestCase
 
   test 'Generates helper correctly' do
     run_generator ['catdog']
-    assert_file 'app/assets/javascripts/helpers/catdog.js', /catdog/
+    assert_file 'appkit/helpers/catdog.js', /catdog/
   end
 end

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -11,17 +11,17 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   test "create model" do
     run_generator ["post", "title:string"]
-    assert_file "app/assets/javascripts/models/post.js.es6"
+    assert_file "appkit/models/post.js.es6"
   end
 
   test "create namespaced model" do
     run_generator ["post/doineedthis", "title:string"]
-    assert_file "app/assets/javascripts/models/post/doineedthis.js.es6"
+    assert_file "appkit/models/post/doineedthis.js.es6"
   end
 
   test "leave parentheses when create model w/o attributes" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/models/post.js.es6", /export default DS.Model.extend/
+    assert_file "appkit/models/post.js.es6", /export default DS.Model.extend/
   end
 
   test "Assert files are properly created" do

--- a/test/generators/resource_generator_test.rb
+++ b/test/generators/resource_generator_test.rb
@@ -10,25 +10,25 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   test "create template" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/templates/post.hbs"
   end
 
   test "create controller" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/controllers/post.js.es6"
+    assert_file "appkit/controllers/post.js.es6"
   end
 
   test "create route" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/routes/post.js.es6"
-    assert_file "app/assets/javascripts/router.js.es6" do |content|
+    assert_file "appkit/routes/post.js.es6"
+    assert_file "appkit/router.js.es6" do |content|
       assert_match(%r{this.resource\('posts'\);}, content)
     end
   end
 
   test "skip route" do
     run_generator ["post", "--skip-route"]
-    assert_no_file "app/assets/javascripts/routes/post.js.es6"
+    assert_no_file "appkit/routes/post.js.es6"
   end
 
   test "Uses config.ember.ember_path" do
@@ -44,7 +44,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   private
 
-  def copy_router(custom_path = 'app/assets/javascripts')
+  def copy_router(custom_path = 'appkit')
     router = File.expand_path("../../../lib/generators/templates/router.js.es6", __FILE__)
     destination = File.expand_path("../../dummy/tmp/#{custom_path}", __FILE__)
     FileUtils.mkdir_p(destination)

--- a/test/generators/resource_override_test.rb
+++ b/test/generators/resource_override_test.rb
@@ -10,12 +10,12 @@ class ResourceOverrideTest < Rails::Generators::TestCase
 
   test "create template without ember" do
     run_generator ["post"]
-    assert_no_file "app/assets/javascripts/templates/post.hbs"
+    assert_no_file "appkit/templates/post.hbs"
   end
 
   test "create template with ember" do
     run_generator ["post", '--ember']
-    assert_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/templates/post.hbs"
   end
 
   private

--- a/test/generators/template_generator_test.rb
+++ b/test/generators/template_generator_test.rb
@@ -11,7 +11,7 @@ class TemplateGeneratorTest < Rails::Generators::TestCase
 
   test "generates template" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/templates/post.hbs"
   end
 
   test "Assert files are properly created with custom path" do

--- a/test/generators/view_generator_test.rb
+++ b/test/generators/view_generator_test.rb
@@ -11,25 +11,25 @@ class ViewGeneratorTest < Rails::Generators::TestCase
 
   test "create view with template by default" do
     run_generator ["post"]
-    assert_file "app/assets/javascripts/views/post.js.es6"
-    assert_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/views/post.js.es6"
+    assert_file "appkit/templates/post.hbs"
   end
 
   test "create view without a template" do
     run_generator ["post", "--without-template"]
-    assert_file "app/assets/javascripts/views/post.js.es6"
-    assert_no_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/views/post.js.es6"
+    assert_no_file "appkit/templates/post.hbs"
   end
 
   test "create view and template (using ember-rails flags)" do
     run_generator ["post", "--with-template"]
-    assert_file "app/assets/javascripts/views/post.js.es6"
-    assert_file "app/assets/javascripts/templates/post.hbs"
+    assert_file "appkit/views/post.js.es6"
+    assert_file "appkit/templates/post.hbs"
   end
 
   test "create namespaced view" do
     run_generator ["post/index"]
-    assert_file "app/assets/javascripts/views/post/index.js.es6"
+    assert_file "appkit/views/post/index.js.es6"
   end
 
   test "Assert files are properly created" do

--- a/test/support/generator_test_support.rb
+++ b/test/support/generator_test_support.rb
@@ -10,6 +10,8 @@ module GeneratorTestSupport
     FileUtils.mkdir_p javascript_destination
     FileUtils.cp "test/fixtures/rails_4-0-0_application.js", javascript_destination.join('application.js')
 
+    FileUtils.mkdir_p tmp_destination.join('appkit')
+
     FileUtils.mkdir_p javascript_destination.join('custom')
     FileUtils.cp "test/fixtures/rails_4-0-0_application.js", javascript_destination.join('custom', 'application.js')
 
@@ -48,6 +50,6 @@ module GeneratorTestSupport
   end
 
   def ember_path(custom_path = nil)
-   "app/assets/javascripts/#{custom_path}".chomp('/')
+    custom_path || "appkit" 
   end
 end


### PR DESCRIPTION
By default `rails g ember:bootstrap` will generate into `appkit/` instead
of `app/assets/javascripts`

Some edge cases likely still exist after this PR.

Closes #66
