### PR TITLE
application template in gem always stale

### DIFF
--- a/lib/ember/appkit/rails.rb
+++ b/lib/ember/appkit/rails.rb
@@ -2,5 +2,6 @@ module Ember::Appkit::Rails; end
 
 require 'ember/appkit/rails/engine'
 require 'ember/appkit/rails/resource_override'
+require 'ember/appkit/rails/sprockets'
 
 Rails::WelcomeController.view_paths = File.expand_path('../rails/templates', __FILE__)

--- a/lib/ember/appkit/rails/sprockets.rb
+++ b/lib/ember/appkit/rails/sprockets.rb
@@ -1,0 +1,29 @@
+require 'sprockets/processed_asset'
+
+module Ember::Appkit::Rails::Sprockets
+  module ProcessedAsset
+    def initialize(environment, logical_path, pathname)
+      super
+
+      _make_ember_application_template_stale(pathname)
+    end
+
+    def init_with(environment, coder)
+      super
+
+      _make_ember_application_template_stale(coder['pathname'])
+    end
+
+    private
+
+    def _make_ember_application_template_stale(pathname)
+      if pathname.to_s =~ /ember-appkit-rails.+\/app\/assets\/javascripts\/templates\/application.hbs/
+        def self.fresh?(environment)
+          false
+        end
+      end
+    end
+  end
+end
+
+Sprockets::ProcessedAsset.send(:prepend, Ember::Appkit::Rails::Sprockets::ProcessedAsset)


### PR DESCRIPTION
This forces sprockets to consider the default application template in
this gem to always be stale. Now the dev does not have to restart their
server when adding their own templates/application.hbs file.

Closes #63
