### PR TITLE
Allow multiple prefix patterns.

### DIFF
--- a/ember-appkit-rails.gemspec
+++ b/ember-appkit-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'rails', '~> 4.0.0'
-  s.add_dependency 'es6_module_transpiler-rails', '~> 0.1.0'
+  s.add_dependency 'es6_module_transpiler-rails', '~> 0.2.0'
   s.add_dependency 'ember-rails', '>= 0.14.0'
   s.add_dependency 'ember-source', '~> 1.2.0.1'
   s.add_dependency 'ember-data-source', '~> 1.0.0.beta.3'

--- a/lib/ember/appkit/rails/engine.rb
+++ b/lib/ember/appkit/rails/engine.rb
@@ -3,12 +3,14 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
 
   config.ember_appkit.namespace = 'appkit'
   config.ember_appkit.asset_path = config.ember_appkit.namespace
-  config.ember_appkit.prefix_pattern = /^(controllers|components|models|views|helpers|routes|router|adapter)/
+  config.ember_appkit.prefix_patterns = [/^(controllers|components|models|views|helpers|routes|router|adapter)/]
 
   config.ember_appkit.enable_logging = ::Rails.env.development?
 
   initializer "ember_appkit.configure" do
-    ES6ModuleTranspiler.prefix_pattern = [config.ember_appkit.prefix_pattern, config.ember_appkit.namespace]
+    config.ember_appkit.prefix_patterns.each do |pattern|
+      ES6ModuleTranspiler.add_prefix_pattern pattern, config.ember_appkit.namespace
+    end
 
     config.handlebars ||= ActiveSupport::OrderedOptions.new
     config.handlebars.output_type   = :amd


### PR DESCRIPTION
Takes advantage of the changes made to the es6_module_transpiler-rails [here](https://github.com/dockyard/es6_module_transpiler-rails/pull/3).

Does not maintain backwards compatibility with prior `config.ember_appkit.prefix_pattern` setting.

Depends on `es6_module_transpiler-rails` > 0.1.0 (needs to be published).

Closes #26.
