### PR TITLE
Properly order Sprockets asset paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+* Fix issue with asset path ordering. See [#96](https://github.com/dockyard/ember-appkit-rails/issues/96) for details.
+
 ## 0.2.0
 
 * Ember-Data setting up - Brian Cardarella

--- a/lib/ember/appkit/rails/engine.rb
+++ b/lib/ember/appkit/rails/engine.rb
@@ -35,7 +35,13 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
   end
 
   initializer :appkit_sprockets do
-    Sprockets::Railtie.config.assets.paths.unshift(File.join(::Rails.root, config.ember.appkit.paths.config))
-    Sprockets::Railtie.config.assets.paths.unshift(File.join(::Rails.root, config.ember.appkit.paths.app))
+    assets = Sprockets::Railtie.config.assets
+
+    assets_javascript = assets.paths.delete(::Rails.root.join('app','assets','javascripts').to_s)
+
+    index_of_last_app_assets = assets.paths.rindex{|s| s.start_with?(::Rails.root.join('app').to_s) } + 1
+    assets.paths.insert(index_of_last_app_assets, assets_javascript) if assets_javascript
+    assets.paths.insert(index_of_last_app_assets, File.join(::Rails.root, config.ember.appkit.paths.config))
+    assets.paths.insert(index_of_last_app_assets, File.join(::Rails.root, config.ember.appkit.paths.app))
   end
 end


### PR DESCRIPTION
Prior to this change we were always inserting `app/` and `config/` to the beginning of the `Sprockets::Railtie.config.assets.paths` array.

Unfortunately, this has the negative impact of matching the lookup of `app/assets/images` and `app/assets/stylesheets` (any other folders under `app/` actually) with a root of `app/` (instead of a root of `app/assets`). This caused the issue detailed in #96 (stylesheets being available at `/assets/assets/application.css` instead of `/assets/application.css`).

This change forces `app/` and `config/` to be inserted after any folders under `app/` other than `app/assets/javascripts` (which we remove in `ember:bootstrap`, but is still dealt with here).

Closes #96.
