### PR TITLE
Remove _component suffix from generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.0
 
 * Fix issue with asset path ordering. See [#96](https://github.com/dockyard/ember-appkit-rails/issues/96) for details.
+* Fix component generator to not add \_component suffix
 
 ## 0.2.0
 

--- a/lib/generators/ember/component_generator.rb
+++ b/lib/generators/ember/component_generator.rb
@@ -11,7 +11,7 @@ module Ember
 
       def create_component_files
         dashed_file_name = file_name.gsub(/_/, '-')
-        component_path = File.join(app_path, 'components', class_path, "#{dashed_file_name}_component.js.es6")
+        component_path = File.join(app_path, 'components', class_path, "#{dashed_file_name}.js.es6")
         template "component.js.es6", component_path
 
         template_path = File.join(app_path, 'templates/components', class_path, "#{dashed_file_name}.hbs")

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -11,31 +11,31 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
   test "default_component" do
     run_generator ["PostChart"]
-    assert_file "#{app_path}/components/post-chart_component.js.es6"
+    assert_file "#{app_path}/components/post-chart.js.es6"
     assert_file "#{app_path}/templates/components/post-chart.hbs"
   end
 
   test "Assert files are properly created (CamelCase)" do
     run_generator %w(PostChart)
-    assert_file "#{app_path}/components/post-chart_component.js.es6"
+    assert_file "#{app_path}/components/post-chart.js.es6"
     assert_file "#{app_path}/templates/components/post-chart.hbs"
   end
 
   test "Assert object names are properly created with CamelCase name" do
     run_generator %w(PostChart)
-    assert_file "#{app_path}/components/post-chart_component.js.es6"
+    assert_file "#{app_path}/components/post-chart.js.es6"
     assert_file "#{app_path}/templates/components/post-chart.hbs"
   end
 
   test "Assert files are properly created (lower-case)" do
     run_generator %w(post-chart)
-    assert_file "#{app_path}/components/post-chart_component.js.es6"
+    assert_file "#{app_path}/components/post-chart.js.es6"
     assert_file "#{app_path}/templates/components/post-chart.hbs"
   end
 
   test "Assert object names are properly created with lower-case name" do
     run_generator %w(post-chart)
-    assert_file "#{app_path}/components/post-chart_component.js.es6"
+    assert_file "#{app_path}/components/post-chart.js.es6"
     assert_file "#{app_path}/templates/components/post-chart.hbs"
   end
 
@@ -44,7 +44,7 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
     with_config paths: {app: custom_path} do
       run_generator ["PostChart"]
-      assert_file "#{custom_path}/components/post-chart_component.js.es6"
+      assert_file "#{custom_path}/components/post-chart.js.es6"
       assert_file "#{custom_path}/templates/components/post-chart.hbs"
     end
   end


### PR DESCRIPTION
`rails g ember:component user-info` currently creates these two files:
- `app/components/user-info_component.js.es6`
- `app/templates/components/user-info.hbs`

The es6 file is exported as `app/components/user-info-component`, while the handlebars file remains `components/user-info`. As a result, there are two half-usable components:
- `{{user-info}}` will render the template properly, but will completely ignore the es6 file. In my case, the `didInsertElement` callback was completely ignored, but the contents of the template were displayed.
- `{{user-info-component}}` will properly load the es6 file, but ignore the template. In my case, the `didInsertElement` callback executed, but the template was not rendered.

Renaming the component file to `app/components/user-info.js.es6` allows full use of `{{user-info}}`. So, this pull request removes the `_component` suffix from the generated es6 files.

(An alternative would be renaming the template files to have `-component` on the end, but then you would always have to use the `{{user-info-component ...}}` format).
