### PR TITLE
configure rails generator

### DIFF
--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -66,6 +66,17 @@ module Ember
         end
       end
 
+      def add_generator_options
+        insert_into_file 'config/application.rb', before: /\s\send\nend/ do
+          "    config.generators do |generate|\n" +
+          "      generate.assets false\n" +
+          "      generate.helper false\n" +
+          "      generate.jbuilder false\n" +
+          "      generate.template_engine false\n" +
+          "    end\n"
+        end
+      end
+
       private
 
       def remove_turbolinks_from_layout

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -71,6 +71,15 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
     confirm_turbolinks_removed "app/views/layouts/application.html.erb"
   end
 
+  test "configures generators to not create views, helpers, layout" do
+    run_generator
+    assert_file "config/application.rb", /config\.generators do \|generate\|/
+    assert_file "config/application.rb", /generate\.helper false/
+    assert_file "config/application.rb", /generate\.assets false/
+    assert_file "config/application.rb", /generate\.jbuilder false/
+    assert_file "config/application.rb", /generate\.template_engine false/
+  end
+
   test "Removed app/assets/javascript directory" do
     run_generator
     assert_no_directory "app/assets/javascripts"


### PR DESCRIPTION
don’t create assets, helpers, jbuilder and templates on `rails scaffold`.

This should address #82 partially.
