### PR TITLE
Fix underfined method in engine.rb

### DIFF
--- a/lib/ember/appkit/rails/engine.rb
+++ b/lib/ember/appkit/rails/engine.rb
@@ -47,7 +47,7 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
 
     assets_javascript = assets.paths.delete(::Rails.root.join('app','assets','javascripts').to_s)
 
-    index_of_last_app_assets = assets.paths.rindex{|s| s.start_with?(::Rails.root.join('app').to_s) } + 1
+    index_of_last_app_assets = assets.paths.rindex{|s| s.to_s.start_with?(::Rails.root.join('app').to_s) } + 1
     assets.paths.insert(index_of_last_app_assets, assets_javascript) if assets_javascript
     assets.paths.insert(index_of_last_app_assets, File.join(::Rails.root, config.ember.appkit.paths.config))
     assets.paths.insert(index_of_last_app_assets, File.join(::Rails.root, config.ember.appkit.paths.app))


### PR DESCRIPTION
I got undefined method `start_with?' against the pathnames returned from assets.paths. Converting to string first fixes the comparison.
