### PR TITLE
remove duplicate dependency on jquery-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ DEPENDENCIES
   byebug
   capybara
   ember-appkit-rails!
-  jquery-rails
   m
   poltergeist
   pry

--- a/ember-appkit-rails.gemspec
+++ b/ember-appkit-rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'barber', '>= 0.4.1'
   s.add_dependency 'active_model_serializers'
 
-  s.add_development_dependency 'jquery-rails'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'
 end


### PR DESCRIPTION
After adding ember-appkit-rails to my Gemfile and running bundle install, I kept getting this warning:

```
ember-appkit-rails at /Users/frabrunelle/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/bundler/gems/ember-appkit-rails-9b18b19cbc22 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on jquery-rails (>= 0, development), (>= 0) use:
    add_runtime_dependency 'jquery-rails', '>= 0', '>= 0'
```
