### PR TITLE
Move default adapter under app/adapters and let resolver resolve the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add commented out history location Router details
 * Changed scaffold to pass context rather than doing model lookup in routes
 * Make environment js files erb to enable reading values from ENV
+* Move config/adapter.js.erb to config/adapters/application.js.es6.erb
+  and make it resolvable by the resolver.
 
 ## 0.3.1
 

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -29,7 +29,7 @@ module Ember
       end
 
       def create_ember_adapter_file
-        template "adapter.js.erb", "#{config_path}/adapter.js.erb"
+        template "adapter.js.erb", "#{config_path}/adapters/application.js.es6.erb"
       end
 
       def create_ember_environment_files

--- a/lib/generators/templates/adapter.js.erb
+++ b/lib/generators/templates/adapter.js.erb
@@ -1,3 +1,3 @@
-window.<%= application_name.camelize %>.ApplicationAdapter = DS.ActiveModelAdapter.extend({
+export default DS.ActiveModelAdapter.extend({
   namespace: 'api/v<%%= Rails.application.config.ember.api_version %>'
 });

--- a/lib/generators/templates/application.js.erb
+++ b/lib/generators/templates/application.js.erb
@@ -2,7 +2,7 @@
 //= require environment
 //= require ember-appkit
 //= require_self
-//= require adapter
+//= require_tree ./adapters
 //= require router
 //= require_tree ../<%= app_path %>
 //= require_tree ./initializers

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -101,7 +101,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
     assert_file "#{config_path}/environments/test.js.erb"
     assert_file "#{config_path}/application.js"
     assert_file "#{config_path}/router.js.es6"
-    assert_file "#{config_path}/adapter.js.erb"
+    assert_file "#{config_path}/adapters/application.js.es6.erb"
     assert_file "#{config_path}/initializers/csrf.js"
   end
 


### PR DESCRIPTION
Removes the need of having window.App defined for specifing an
adapter, now it will be resolved by the resolver. Will also facilitate
things for adding tests with QUnit.
