### PR TITLE
Start Ember App on application layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Make sure attributes are camelized in scaffold templates.
 * Add Teaspoon integration by default https://github.com/modeset/teaspoon.
 * Generate test automatically when running scaffold.
+* Initialize App on application layout.
 
 ## 0.4.0
 

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -59,6 +59,15 @@ module Ember
         remove_jbuilder_from_gemfile
       end
 
+      def add_ember_app_create_to_layout
+        path = Pathname.new(destination_root).join('app','views','layouts','application.html.erb')
+        return unless path.exist?
+
+        inject_into_file path, after: "<%= yield %>" do
+          "\n\n<script>\n  window.#{application_name.camelize} = require('app').default.create();\n</script>"
+        end
+      end
+
       def add_greedy_rails_route
         insert_into_file 'config/routes.rb', before: /^end$/ do
           "\n" +

--- a/lib/generators/templates/application.js.erb
+++ b/lib/generators/templates/application.js.erb
@@ -7,5 +7,3 @@
 //= require router
 //= require_tree ../<%= app_path %>
 //= require_tree ./initializers
-
-window.<%= application_name.camelize %> = require('app').default.create();

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -39,7 +39,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
   test "create bootstrap with custom app name" do
     run_generator ["-n", "MyApp"]
 
-    assert_file "#{config_path}/application.js", /MyApp = /
+    assert_file "app/views/layouts/application.html.erb", /MyApp = /
 
     assert_files
   end
@@ -49,7 +49,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
       run_generator
 
       assert_files
-      assert_file "#{config_path}/application.js", /Blazorz = /
+      assert_file "app/views/layouts/application.html.erb", /Blazorz = /
     end
   end
 


### PR DESCRIPTION
When we require application.js it start the app automatically which becomes conflictive when adding test (I'm currently adding integration with teaspoon).

With this change we will have more control in tests for starting our app.
