### PR TITLE
Prepare for updated Resolver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 * add `lib/` to the asset load path
 * Rewrote config/routes.rb walker to properly revoke and invoke
   depending upon generator
-* App config settings now exposed in congig/environments/\*.js.erb
+* App config settings now exposed in config/environments/\*.js.erb
+* Use custom type specific prefixes in preparation for the updated Resolver.
+* Centralize resolver namespace configuration into a single place (`config/environments`).
 
 ## 0.3.1
 

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -33,10 +33,10 @@ module Ember
       end
 
       def create_ember_environment_files
-        template "environment.js", "#{config_path}/environment.js"
-        template "environments/development.js.erb", "#{config_path}/environments/development.js.erb"
-        template "environments/production.js.erb", "#{config_path}/environments/production.js.erb"
-        template "environments/test.js.erb", "#{config_path}/environments/test.js.erb"
+        copy_file "environment.js.erb", "#{config_path}/environment.js.erb"
+        copy_file "environments/development.js.erb", "#{config_path}/environments/development.js.erb"
+        copy_file "environments/production.js.erb", "#{config_path}/environments/production.js.erb"
+        copy_file "environments/test.js.erb", "#{config_path}/environments/test.js.erb"
       end
 
       def create_utils_csrf_file

--- a/lib/generators/templates/environment.js.erb
+++ b/lib/generators/templates/environment.js.erb
@@ -10,3 +10,10 @@
 */
 
 window.config = {};
+
+<% config = Rails.application.config.ember %>
+
+config.modulePrefix     = '<%= config.namespaces.app %>';
+config.routerPrefix     = '<%= config.namespaces.config %>';
+config.adapterPrefix    = '<%= config.namespaces.config %>';
+config.serializerPrefix = '<%= config.namespaces.config %>';

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -95,7 +95,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
   private
 
   def assert_files(app_path = app_path, config_path = config_path)
-    assert_file "#{config_path}/environment.js"
+    assert_file "#{config_path}/environment.js.erb"
     assert_file "#{config_path}/environments/development.js.erb"
     assert_file "#{config_path}/environments/production.js.erb"
     assert_file "#{config_path}/environments/test.js.erb"

--- a/vendor/assets/javascripts/app.js.es6.erb
+++ b/vendor/assets/javascripts/app.js.es6.erb
@@ -6,8 +6,6 @@ if (typeof Turbolinks !== 'undefined') {
 }
 
 var App = Ember.Application.extend({
-  modulePrefix: '<%= config.namespaces.app %>',
-  configPrefix: '<%= config.namespaces.config %>',
   Resolver: Resolver
 }, window.config);
 

--- a/vendor/assets/javascripts/ember-appkit/resolver_ext.js
+++ b/vendor/assets/javascripts/ember-appkit/resolver_ext.js
@@ -1,59 +1,40 @@
 (function() {
   var Resolver = require('resolver').default;
+  var originalResolveOther = Resolver
 
-  function resolveRouter(parsedName) {
+  function resolveCustomPrefix(parsedName) {
     /*jshint validthis:true */
 
-    var prefix = this.namespace.configPrefix,
-        routerModule;
+    var prefix = this.namespace.modulePrefix,
+        type = parsedName.type,
+        name = parsedName.fullNameWithoutType,
+        tmpModuleName, moduleName, module;
 
-    if (parsedName.fullName === 'router:main') {
-      // for now, lets keep the router at app/router.js
-      if (requirejs._eak_seen[prefix + '/router']) {
-        routerModule = require(prefix + '/router');
-        if (routerModule['default']) { routerModule = routerModule['default']; }
-
-        return routerModule;
-      }
+    if (this.namespace[type + 'Prefix']) {
+      prefix = this.namespace[type + 'Prefix'];
     }
-  }
 
-  function resolveSerializer(parsedName) {
-    /*jshint validthis:true */
-
-    var prefix = this.namespace.configPrefix,
-        serializerModule, serializerName;
-
-    if (parsedName.fullName.match(/serializer:/)) {
-      serializerName = parsedName.fullName.split(/serializer:/)[1];
-      if (requirejs._eak_seen[prefix + '/serializers/' + serializerName]) {
-        serializerModule = require(prefix + '/serializers/' + serializerName);
-        if (serializerModule['default']) { serializerModule = serializerModule['default']; }
-
-        return serializerModule;
-      }
+    tmpModuleName = prefix + '/' + type;
+    if (name === 'main' && requirejs._eak_seen[tmpModuleName]) {
+      moduleName = tmpModuleName;
+    } else {
     }
-  }
 
-  function resolveAdapter(parsedName) {
-    /*jshint validthis:true */
+    if (!moduleName) { moduleName = prefix + '/' + type + 's/' + name; }
 
-    var prefix = this.namespace.configPrefix,
-        adapterModule, adapterName;
+    if (requirejs._eak_seen[moduleName]) {
+      module = require(moduleName);
+      if (module['default']) { module = module['default']; }
 
-    if (parsedName.fullName.match(/adapter:/)) {
-      adapterName = parsedName.fullName.split(/adapter:/)[1];
-      if (requirejs._eak_seen[prefix + '/adapters/' + adapterName]) {
-        adapterModule = require(prefix + '/adapters/' + adapterName);
-        if (adapterModule['default']) { adapterModule = adapterModule['default']; }
-
-        return adapterModule;
-      }
+      return module;
+    } else {
+      return this.resolveOther(parsedName);
     }
   }
 
   Resolver.reopen({
-    resolveRouter: resolveRouter,
-    resolveAdapter: resolveAdapter
+    resolveRouter: resolveCustomPrefix,
+    resolveAdapter: resolveCustomPrefix,
+    resolveSerializer: resolveCustomPrefix
   });
 })();


### PR DESCRIPTION
Prepare for updated Resolver.
- Makes `config/environments.js` into an ERB file.
- Uses `copy_file` instead of `template` in `ember:boostrap`. `template`
  is used to evaluate the template at generator runtime (which is NOT
  what we want).
- Centralizes the namespace configuration into `config/environment.js.erb`.
- Adds a custom method to the Resolver for `resolveSerializer`.
- Uses `typePrefix` to resolve adapters, serializers, and the Router.

There is a PR pending on the resolver repo to make the behavior in
`resolver_ext.js` not needed at all (we can remove it).
