### PR TITLE
Fix typo in adapter template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Fix typo in `adapter.js.es6.erb` template.
+
 ## 0.4.0
 
 * Changed Rails controller to use respond\_with instead of render

--- a/lib/generators/templates/adapter.js.erb
+++ b/lib/generators/templates/adapter.js.erb
@@ -1,3 +1,3 @@
 export default DS.ActiveModelAdapter.extend({
-  namespace: 'api/v<%%= Rails.application.config.ember.api_version %>'
+  namespace: 'api/v<%= Rails.application.config.ember.api_version %>'
 });


### PR DESCRIPTION
We likely should roll 0.4.1 with this update, and possibly #156.
