### PR TITLE
Move adapter template into subdirectory.

### DIFF
--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -29,7 +29,7 @@ module Ember
       end
 
       def create_ember_adapter_file
-        template "adapter.js.erb", "#{config_path}/adapters/application.js.es6.erb"
+        copy_file "adapters/application.js.es6.erb", "#{config_path}/adapters/application.js.es6.erb"
       end
 
       def create_ember_environment_files

--- a/lib/generators/templates/adapter.js.erb
+++ b/lib/generators/templates/adapter.js.erb
@@ -1,3 +1,0 @@
-export default DS.ActiveModelAdapter.extend({
-  namespace: 'api/v<%%= Rails.application.config.ember.api_version %>'
-});

--- a/lib/generators/templates/adapters/application.js.es6.erb
+++ b/lib/generators/templates/adapters/application.js.es6.erb
@@ -1,0 +1,3 @@
+export default DS.ActiveModelAdapter.extend({
+  namespace: 'api/v<%= Rails.application.config.ember.api_version %>'
+});


### PR DESCRIPTION
Also, uses `copy_file` instead of `template` to avoid manually escaping the
ERB tags.
