### PR TITLE
Update to Ember 1.4.0-beta.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.0
 
 * Update to latest resolver. Removes need for monkey-patch.
+* Update to Ember 1.4 to resolve issue with loading and error substates.
 
 ## 0.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       active_model_serializers
       barber (>= 0.4.1)
       ember-data-source (~> 1.0.0.beta.3)
-      ember-source (~> 1.3)
+      ember-source (~> 1.4.beta)
       es6_module_transpiler-rails (~> 0.3.0)
       handlebars-source
       jquery-rails
@@ -64,13 +64,13 @@ GEM
     debugger-linecache (1.2.0)
     ember-data-source (1.0.0.beta.5)
       ember-source
-    ember-source (1.3.1.1)
-      handlebars-source (~> 1.2.1)
+    ember-source (1.4.0.beta.2)
+      handlebars-source (~> 1.3.0)
     erubis (2.7.0)
     es6_module_transpiler-rails (0.3.0)
       execjs
     execjs (2.0.2)
-    handlebars-source (1.2.1)
+    handlebars-source (1.3.0)
     hike (1.2.3)
     i18n (0.6.9)
     jquery-rails (3.0.4)

--- a/ember-appkit-rails.gemspec
+++ b/ember-appkit-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~>4.0'
   s.add_dependency 'parser'
   s.add_dependency 'es6_module_transpiler-rails', '~> 0.3.0'
-  s.add_dependency 'ember-source', '~> 1.3'
+  s.add_dependency 'ember-source', '~> 1.4.beta'
   s.add_dependency 'ember-data-source', '~> 1.0.0.beta.3'
   s.add_dependency 'handlebars-source'
   s.add_dependency 'jquery-rails'


### PR DESCRIPTION
Ember 1.3 does not properly normalize the looked up template/route names. This
causes loading and error states to not work under our updated resolver (since
we rely on path normalization).

For reference:

https://github.com/stefanpenner/ember-jj-abrams-resolver/issues/13
https://github.com/stefanpenner/ember-app-kit/issues/427
https://github.com/stefanpenner/ember-app-kit/issues/428
