### PR TITLE
Ensure that window.config is an object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update to latest resolver. Removes need for monkey-patch.
 * Update to Ember 1.4 to resolve issue with loading and error substates.
+* Add a default value for `window.config` to prevent errors if the environment configuration is not present.
 
 ## 0.4.0
 

--- a/vendor/assets/javascripts/app.js.es6.erb
+++ b/vendor/assets/javascripts/app.js.es6.erb
@@ -5,6 +5,8 @@ if (typeof Turbolinks !== 'undefined') {
   throw new Error("Turbolinks has been detected. Ember Appkit Rails will not function properly alongside Turbolinks.");
 }
 
+if (window.config === undefined) { window.config = {}; }
+
 var App = Ember.Application.extend({
   Resolver: Resolver
 }, window.config);


### PR DESCRIPTION
This prevents bizarre errors that occur if a user has not ran the
`ember:bootstrap` generator since the config refactor in 
https://github.com/dockyard/ember-appkit-rails/pull/148.
