### PR TITLE
New path for Rails serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Ensure that the `config/serializers/` directory is mounted properly by Sprockets.
 * Updates `.js.es6` extensions to the preferred  `.es6` file extensions.
 * Changes generated Rails controller error responses
+* Rails serializers are generated under `config/serializers`.
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following is added to your `config/` directory:
 * `config/environments/development.js` development environment settings
 * `config/environments/production.js` production environment settings
 * `config/environments/test.js` test environment settings
+* `config/serializers/` where Rails and Ember serializers will go
 
 The `lib/` directory is also mounted into the asset load path. You
 should use `lib/` to write any custom code that does not belong in

--- a/lib/ember/appkit/rails/engine.rb
+++ b/lib/ember/appkit/rails/engine.rb
@@ -20,6 +20,7 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
     require 'generators/ember/resource_override'
     require 'generators/ember/scaffold_override'
     require 'generators/ember/scaffold_controller_override'
+    require 'generators/ember/serializer_override'
   end
 
   initializer :appkit_transpiler do
@@ -55,6 +56,10 @@ class Ember::Appkit::Rails::Engine < ::Rails::Engine
     app.routes.append do
       get '/' => "landing#index"
     end
+  end
+
+  initializer :appkit_serializer, before: :set_autoload_paths do |app|
+    app.config.paths.add File.join(Rails.root, 'config/serializers'), eager_load: true
   end
 
   initializer :appkit_sprockets do

--- a/lib/generators/ember/serializer_override.rb
+++ b/lib/generators/ember/serializer_override.rb
@@ -1,0 +1,12 @@
+require "rails/generators"
+require "generators/serializer/serializer_generator"
+
+module Rails
+  module Generators
+    SerializerGenerator.class_eval do
+      def create_serializer_file
+        template 'serializer.rb', File.join('config/serializers', class_path, "#{file_name}_serializer.rb")
+      end
+    end
+  end
+end

--- a/test/generators/serializer_override_test.rb
+++ b/test/generators/serializer_override_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class SerializerOverrideTest < Rails::Generators::TestCase
+  include GeneratorTestSupport
+
+  tests Rails::Generators::SerializerGenerator
+  destination File.join(Rails.root, "tmp")
+  setup :prepare_destination
+
+  test "create serializer under config/serializers" do
+    run_generator ["post"]
+    assert_file "#{config_path}/serializers/post_serializer.rb"
+  end
+
+  test "does not create serializer under app/serializers" do
+    run_generator ["post"]
+    assert_no_file "#{app_path}/serializers/post_serializer.rb"
+  end
+end

--- a/test/integration/engine_test.rb
+++ b/test/integration/engine_test.rb
@@ -5,6 +5,10 @@ class EngineTest < ActionDispatch::IntegrationTest
     refute Rails.application.config.assets.paths.include?(File.join(Rails.root, 'app/assets/javascripts'))
   end
 
+  test 'config/serializers is added to autoload_path' do
+    assert Rails.application.config.paths.eager_load.include?(File.join(Rails.root, 'config/serializers'))
+  end
+
   test 'app is in the asset load path' do
     assert Rails.application.config.assets.paths.include?(File.join(Rails.root, 'app'))
   end


### PR DESCRIPTION
With this change Rails serializers are going to be placed under
`config/serializers` along side with Ember ones.

Fixes #162

@bcardarella + @twokul
