### PR TITLE
Update to Ember Data 1.0.0-beta.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updates `.js.es6` extensions to the preferred  `.es6` file extensions.
 * Changes generated Rails controller error responses
 * Rails serializers are generated under `config/serializers`.
+* Update to Ember Data 1.0.0-beta.6 to resolve adapter/serializer resolution issues.
 
 ## 0.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ember-appkit-rails (0.4.0)
       active_model_serializers
       barber (>= 0.4.1)
-      ember-data-source (~> 1.0.0.beta.3)
+      ember-data-source (~> 1.0.0.beta.6)
       ember-source (~> 1.4.beta)
       es6_module_transpiler-rails (~> 0.3.0)
       handlebars-source
@@ -62,9 +62,9 @@ GEM
     coderay (1.1.0)
     columnize (0.3.6)
     debugger-linecache (1.2.0)
-    ember-data-source (1.0.0.beta.5)
+    ember-data-source (1.0.0.beta.6)
       ember-source
-    ember-source (1.4.0.beta.2)
+    ember-source (1.4.0.beta.3)
       handlebars-source (~> 1.3.0)
     erubis (2.7.0)
     es6_module_transpiler-rails (0.3.0)

--- a/ember-appkit-rails.gemspec
+++ b/ember-appkit-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'parser'
   s.add_dependency 'es6_module_transpiler-rails', '~> 0.3.0'
   s.add_dependency 'ember-source', '~> 1.4.beta'
-  s.add_dependency 'ember-data-source', '~> 1.0.0.beta.3'
+  s.add_dependency 'ember-data-source', '~> 1.0.0.beta.6'
   s.add_dependency 'handlebars-source'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'barber', '>= 0.4.1'


### PR DESCRIPTION
This resolves an issue with the new resolver dasherizing names which caused
the _ams adapter to not be found due to the resolver dasherizing the looked-up
names.
