### PR TITLE
Use quoted action names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Update to Ember Data 1.0.0-beta.6 to resolve adapter/serializer resolution issues.
 * Scaffold, put `input` inside `label` instead of having an empty `for` (#a85bde2).
 * Scaffold, add default classes to templates.
+* Scaffold: use quoted action names (prepare for bound action lookup added [here](https://github.com/emberjs/ember.js/pull/3936)).
 
 ## 0.4.0
 

--- a/lib/generators/templates/scaffold/template/form.hbs
+++ b/lib/generators/templates/scaffold/template/form.hbs
@@ -4,5 +4,5 @@
 </div>
 <% end -%>
 
-<button type="submit" {{action save this}}>Save</button>
-<button type="submit" {{action cancel this}}>Cancel</button>
+<button type="submit" {{action 'save' this}}>Save</button>
+<button type="submit" {{action 'cancel' this}}>Cancel</button>

--- a/lib/generators/templates/scaffold/template/show.hbs
+++ b/lib/generators/templates/scaffold/template/show.hbs
@@ -1,6 +1,6 @@
 <h3>{{id}}</h3>
 
-<p>{{link-to 'Edit' '<%= file_name.pluralize -%>.edit' this}} <button {{action destroyRecord this}}>Destroy</button></p>
+<p>{{link-to 'Edit' '<%= file_name.pluralize -%>.edit' this}} <button {{action 'destroyRecord' this}}>Destroy</button></p>
 
 <ul>
 <% attributes.each do |attribute| -%>


### PR DESCRIPTION
Actions can now use bound property lookup (instead of being static strings).

This was added in https://github.com/emberjs/ember.js/pull/3936.
