### PR TITLE
ember:bootstrap creates directory structure for custom --app-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Scaffold, add default classes to templates.
 * Scaffold: use quoted action names (prepare for bound action lookup added [here](https://github.com/emberjs/ember.js/pull/3936)).
 * [fixed] generator error for custum app and config path
+* Bootstrap generates all necessary directories when using a custom app-path
 
 ## 0.4.0
 

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -13,10 +13,17 @@ module Ember
       class_option :config_path, :type => :string, :aliases => "-c", :default => false, :desc => "Custom ember config path"
       class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
 
-      def create_dir_layout
-        %W{routes components templates templates/components mixins ../config/serializers}.each do |dir|
+      def create_app_dir_layout
+        %W{models controllers views routes components templates templates/components mixins}.each do |dir|
           empty_directory "#{app_path}/#{dir}"
           create_file "#{app_path}/#{dir}/.gitkeep" unless options[:skip_git]
+        end
+      end
+
+      def create_config_dir_layout
+        %W{serializers}.each do |dir|
+          empty_directory "#{config_path}/#{dir}"
+          create_file "#{config_path}/#{dir}/.gitkeep" unless options[:skip_git]
         end
       end
 

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -95,6 +95,11 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
   private
 
   def assert_files(app_path = app_path, config_path = config_path)
+    %W{models controllers views routes components templates templates/components mixins}.each do |dir|
+      assert_directory "#{app_path}/#{dir}"
+    end
+    assert_directory "#{config_path}/serializers"
+
     assert_file "#{config_path}/environment.js.erb"
     assert_file "#{config_path}/environments/development.js.erb"
     assert_file "#{config_path}/environments/production.js.erb"


### PR DESCRIPTION
The generator was not creating the models, controllers, views directories for a custom app-path.
