### PR TITLE
Support latest alpha of active_model_serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Generate test automatically when running scaffold.
 * Add option to get custom Ember builds.
 * jj-abrams-resolver now lives under the module name ember/resolver per [here](https://github.com/stefanpenner/ember-jj-abrams-resolver/pull/27).
+* Add suport for latest serializer alpha
 
 ## 0.4.0
 

--- a/lib/generators/ember/serializer_override.rb
+++ b/lib/generators/ember/serializer_override.rb
@@ -1,5 +1,11 @@
 require "rails/generators"
+
+begin
 require "generators/serializer/serializer_generator"
+rescue LoadError
+# TODO: Make this primary when active_model_serializers 0.9.0 is final
+require "active_model/serializer/generators/serializer/serializer_generator"
+end
 
 module Rails
   module Generators


### PR DESCRIPTION
I tried upgrading eakr in an app where I'm using active_model_serializers on head. Looks like this file was moved at some point before the latest alpha. This gets us support for both older & newer releases of AMS and when 0.9.0 is official we can delete the rescue block.
