### PR TITLE
Reset csrf meta tag based on presence of headers

### DIFF
--- a/lib/generators/templates/csrf.js
+++ b/lib/generators/templates/csrf.js
@@ -7,3 +7,15 @@ $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
     }
   }
 });
+
+$(document).on("ajaxComplete", function(event, xhr, settings) {
+  var csrf_param = xhr.getResponseHeader('X-CSRF-Param');
+  var csrf_token = xhr.getResponseHeader('X-CSRF-Token');
+
+  if (csrf_param) {
+    $('meta[name="csrf-param"]').attr('content', csrf_param);
+  }
+  if (csrf_token) {
+    $('meta[name="csrf-token"]').attr('content', csrf_token);
+  }
+});


### PR DESCRIPTION
We're setting up authentication with devise and trying to just use the default session cookies. The only problem, as you probably already know, was resetting the CSRF token after sign-in/sign-out. Since we're already grabbing the token from the meta to send it up to the server, what do you think about adding the following to the `csrf.js` initializer template in the initializer?

This approach is based on the following stack overflow post:

http://stackoverflow.com/questions/20875591/actioncontrollerinvalidauthenticitytoken-in-registrationscontrollercreate

We're setting these headers in an after filter on a custom `SessionsController` that inherits from `Devise::SessionsController`. It would still be on the developer to send those tokens back in a header somewhere, but I think that's reasonable.
