### PR TITLE
Fixes testing generator errors

### DIFF
--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'generators/ember/install_generator'
 require 'vcr'
 
-
 class InstallGeneratorTest < Rails::Generators::TestCase
   tests Ember::Generators::InstallGenerator
   destination File.join(Rails.root, "tmp", "generator_test_output")
@@ -32,7 +31,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "without any options it load the release channel" do
-
     VCR.use_cassette('fetch_ember_release') do
       run_generator
       assert_all_ember_files
@@ -47,7 +45,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       # assert_all_ember_data_files TODO: Remove after ember data is released
     end
   end
-
 
   test "with options channel=beta it should load the beta ember-data & ember files" do
     VCR.use_cassette('fetch_ember_beta') do
@@ -67,7 +64,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "with unknown channel option it should raise exception InvalidChannel" do
     assert_raise ::InvalidChannel do
-      run_generator ['--channel=unkown']
+      run_generator ['--channel=unkown'], debug: true
     end
     assert_no_ember_files
     assert_no_ember_data_files
@@ -97,7 +94,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_all_ember_data_files
   end
 
-
   test "option --ember-data aliasses --ember_data_only" do
     VCR.use_cassette('fetch_ember_beta') do
       run_generator ['--ember-data', '--channel=beta']
@@ -106,7 +102,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_all_ember_data_files
   end
 
-
   test "with options --tag=v1.0.0-beta.1 --ember-data" do
     VCR.use_cassette('fetch_ember_data_tagged') do
       run_generator ['--tag=v1.0.0-beta.1', '--ember-data']
@@ -114,7 +109,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_no_ember_files
     assert_all_ember_data_files
   end
-
 
   test "with option --tag=v1.2.0-beta.2 --ember" do
     VCR.use_cassette('fetch_ember_tagged') do
@@ -126,7 +120,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "with options --channel set and options --tag it should raise exception ConflictingOptions" do
     assert_raise ::ConflictingOptions do
-      run_generator ['--channel=canary', '--tag=v1.2.0-beta.2/ember']
+      run_generator ['--channel=canary', '--tag=v1.2.0-beta.2/ember'], debug: true
     end
     assert_no_ember_files
     assert_no_ember_data_files
@@ -134,12 +128,13 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "with options --tag without --ember or --ember-data it should raise exception InsufficientOptions" do
     assert_raise ::InsufficientOptions do
-      run_generator ['--tag=v1.2.0-beta.2']
+      run_generator ['--tag=v1.2.0-beta.2'], debug: true
     end
     assert_no_ember_files
     assert_no_ember_data_files
   end
 
+  private
 
   def assert_all_ember_files
     assert_file "vendor/assets/javascripts/ember.js"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
 require 'capybara/rails'
 require 'capybara/poltergeist'
+require 'minitest/pride'
 
 Capybara.current_driver = :poltergeist
 


### PR DESCRIPTION
- Adds `debug` flag to generator tests
- Essentially, Thor's default behavior is to print the error message
  instead of raising an exception. Adding the `debug` flag allows us
  to raise the exception explicitly.
  - See: https://github.com/rails/rails/issues/14416
- Cleans up empty lines
- Adds `minitest/pride`
